### PR TITLE
There is now a uniform-cost search and Zones of Control

### DIFF
--- a/Assets/Scripts/ActionMove.cs
+++ b/Assets/Scripts/ActionMove.cs
@@ -57,7 +57,7 @@ public class ActionMove : Action
             {
                 // Center of tile reached
                 transform.position = target;
-                spentActionPoints += 1;
+                spentActionPoints += tile.GetMoveCost();
                 path.Pop();
             }
         }

--- a/Assets/Scripts/CombatController.cs
+++ b/Assets/Scripts/CombatController.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 
 public class CombatController : MonoBehaviour
 {
+    private HashSet<Tile> visitedTiles = new HashSet<Tile>();
     protected List<Tile> selectableTiles = new List<Tile>();
 
     private Tile currentTile;
@@ -10,13 +11,21 @@ public class CombatController : MonoBehaviour
     public bool isTurn = false;
     protected bool isActing = false;
     [SerializeField] private int move = 5;
-    private int actionPoints = 0;
+    [SerializeField] private int actionPoints = 0;
 
     const int ATTACK_COST = 4;
 
     protected void Start()
     {
         AssignCurrentTile();
+    }
+    
+    public void AssignZonesOfControl()
+    {
+        foreach (Tile adjacentTile in currentTile.adjacentTileList)
+        {
+            adjacentTile.isZoneOfControl = true;
+        }
     }
 
     public void BeginTurn()
@@ -25,22 +34,28 @@ public class CombatController : MonoBehaviour
         currentTile.isCurrent = true;
         isTurn = true;
         actionPoints = move;
+        FindSelectableTiles();
     }
 
     // Defaults to false, but can be overridden by subclasses.
-    virtual protected bool CanAttack(Tile tile)
+    // Note that 'enemy' is from the perspective of the actor;
+    // for player-controlled, enemies are AI and vice versa.
+    virtual protected bool ContainsEnemy(Tile tile)
     {
         return false;
     }
 
-    private void AttachTile(int moveCost, Tile adjacentTile, Tile parent)
+    private void AttachTile(int moveCostOverride, Tile adjacentTile, Tile parent)
     {
-        if (parent != currentTile)
+        adjacentTile.parent = parent;
+        if (moveCostOverride != -1)
         {
-            adjacentTile.parent = parent;
+            adjacentTile.distance = moveCostOverride + parent.distance;
         }
-        adjacentTile.distance = moveCost + parent.distance;
-        adjacentTile.wasVisited = true;
+        else
+        {
+            adjacentTile.distance = adjacentTile.GetMoveCost() + parent.distance;
+        }
     }
 
     protected void FindSelectableTiles()
@@ -51,33 +66,46 @@ public class CombatController : MonoBehaviour
         }
         AssignCurrentTile();
 
-        Queue<Tile> queue = new Queue<Tile>();
-        currentTile.wasVisited = true;
-        queue.Enqueue(currentTile);
+        // TODO: Replace with PriorityQueue for performance optimization
+        List<Tile> queue = new List<Tile>();
+        queue.Add(currentTile);
+        visitedTiles.Add(currentTile);
 
         while (queue.Count > 0)
         {
-            Tile tile = queue.Dequeue();
+            queue.Sort((item1, item2) => item1.distance.CompareTo(item2.distance));
+            Tile tile = queue[0];
+            queue.RemoveAt(0);
 
-            selectableTiles.Add(tile);
-            tile.isSelectable = true;
-            if (tile.distance >= actionPoints) continue;
+            if (tile != currentTile)
+            {
+                selectableTiles.Add(tile);
+                tile.isSelectable = true;
+            }
 
             foreach (Tile adjacentTile in tile.adjacentTileList)
             {
-                if (adjacentTile.wasVisited) continue;
                 if (adjacentTile.isBlocked) {
-                    if (CanAttack(adjacentTile) && (tile.distance + ATTACK_COST <= actionPoints))
+                    if (!adjacentTile.wasVisited && ContainsEnemy(adjacentTile) && (tile.distance + ATTACK_COST <= actionPoints))
                     {
                         AttachTile(ATTACK_COST, adjacentTile, tile);
+                        visitedTiles.Add(adjacentTile);
+                        adjacentTile.wasVisited = true;
                         selectableTiles.Add(adjacentTile);
                         adjacentTile.isSelectable = true;
                     }
                     continue;
                 }
-                // Basic moves cost one action point per tile.
-                AttachTile(1, adjacentTile, tile);
-                queue.Enqueue(adjacentTile);
+                if (!adjacentTile.wasVisited || adjacentTile.IsFasterParent(tile))
+                {
+                    if (GetTotalDistanceWithParent(tile) <= actionPoints)
+                    {
+                        adjacentTile.wasVisited = true;
+                        visitedTiles.Add(adjacentTile);
+                        AttachTile(-1, adjacentTile, tile);
+                        queue.Add(adjacentTile);
+                    }
+                }
             }
         }
     }
@@ -88,10 +116,15 @@ public class CombatController : MonoBehaviour
         {
             currentTile.occupant = null;
             currentTile.isBlocked = false;
+            currentTile.isCurrent = false;
         }
         currentTile = GetTargetTile(gameObject);
         currentTile.isBlocked = true;
         currentTile.occupant = gameObject;
+        if (isTurn)
+        {
+            currentTile.isCurrent = true;
+        }
     }
 
     // Will need adjustment once there are objects that units can stand on, e.g., crates
@@ -115,31 +148,31 @@ public class CombatController : MonoBehaviour
 
     protected void EndTurn()
     {
-
         isTurn = false;
         currentTile.isCurrent = false;
     }
 
     public void EndAction(int spentActionPoints)
     {
-        RemoveSelectableTiles();
-        isActing = false;
+        ClearVisitedTiles();
         actionPoints -= spentActionPoints;
         AssignCurrentTile();
-        if (actionPoints <= 0)
+        FindSelectableTiles();
+        isActing = false;
+        if (selectableTiles.Count <= 0)
         {
             EndTurn();
         }
     }
 
-    private void RemoveSelectableTiles()
+    private void ClearVisitedTiles()
     {
-
-        foreach (Tile tile in selectableTiles)
+        selectableTiles.Clear();
+        foreach (Tile tile in visitedTiles)
         {
             tile.ClearMovementVariables();
         }
 
-        selectableTiles.Clear();
+        visitedTiles.Clear();
     }
 }

--- a/Assets/Scripts/EnemyController.cs
+++ b/Assets/Scripts/EnemyController.cs
@@ -5,10 +5,10 @@ using UnityEngine;
 public class EnemyController : CombatController
 {
 
-    override protected bool CanAttack(Tile tile)
+    override protected bool ContainsEnemy(Tile tile)
     {
         if (tile.occupant == null) return false;
-        return tile.occupant.GetComponent<PlayerController>() != null;
+        return tile.HasPC();
     }
 
     // Update is called once per frame
@@ -21,7 +21,6 @@ public class EnemyController : CombatController
         }
         if (!isActing)
         {
-            FindSelectableTiles();
             Tile choice = AIChooseMove();
             if (choice == null)
             {
@@ -70,7 +69,7 @@ public class EnemyController : CombatController
     // returns 100 minus its distance from the target.
     float EvaluateMove(Tile tile, GameObject target)
     {
-        if (CanAttack(tile)) {
+        if (ContainsEnemy(tile)) {
             return 100.0f;
         }
         if (tile.occupant != null) return -1.0f; // Invalid choice, can't move to an occupied tile

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -11,16 +11,14 @@ public class PlayerController : CombatController
         }
         if (!isActing)
         {
-            // Only need to recalculate selectable tiles after action is concluded.
-            FindSelectableTiles();
             CheckMouseClick();
         }
     }
 
-    override protected bool CanAttack(Tile tile)
+    override protected bool ContainsEnemy(Tile tile)
     {
         if (tile.occupant == null) return false;
-        return tile.occupant.GetComponent<EnemyController>() != null;
+        return tile.HasNPC();
     }
 
     private void CheckMouseClick()

--- a/Assets/Scripts/Tile.cs
+++ b/Assets/Scripts/Tile.cs
@@ -8,6 +8,7 @@ public class Tile : MonoBehaviour
     public bool isBlocked = false;
     public bool isTarget = false;
     public bool isSelectable = false;
+    public bool isZoneOfControl = false;
 
     public List<Tile> adjacentTileList = new List<Tile>();
 
@@ -45,6 +46,40 @@ public class Tile : MonoBehaviour
         {
             GetComponent<Renderer>().material.color = Color.white;
         }
+    }
+
+    public bool HasPC()
+    {
+        return occupant.GetComponent<PlayerController>() != null;
+    }
+
+    public bool HasNPC()
+    {
+        return occupant.GetComponent<EnemyController>() != null;
+    }
+
+    public bool IsFasterParent(Tile newParent)
+    {
+        return GetTotalDistanceWithParent(newParent) < distance;
+    }
+
+    public int GetTotalDistanceWithParent(Tile newParent)
+    {
+        return newParent.distance + GetMoveCostForParent(newParent);
+    }
+
+    private int GetMoveCostForParent(Tile measureParent)
+    {
+        if (isCurrent) return 0; // You don't pay a move point for entering your current tile.
+        if (measureParent == null) return 1;
+        if (measureParent.isZoneOfControl) return 2;
+        return 1;
+    }
+
+    // Cost to enter the tile.
+    public int GetMoveCost()
+    {
+        return GetMoveCostForParent(parent);
     }
 
     public void ClearMovementVariables()


### PR DESCRIPTION
Movement has been changed from a breadth-first search to a uniform-cost search, which allows tiles to have different move costs. Furthermore, units exert a zone of control such that leaving a tile adjacent to a foe costs more action points.