### PR TITLE
Aveybranch

### DIFF
--- a/Assets/Scenes/Combat.unity
+++ b/Assets/Scenes/Combat.unity
@@ -14179,7 +14179,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 866748467}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: 2.5, y: 0.08, z: 2.5}
   m_LocalScale: {x: 0.9, y: 0.9, z: 0.9}
   m_Children:
@@ -14188,7 +14188,7 @@ Transform:
   - {fileID: 1081556312}
   m_Father: {fileID: 202990525}
   m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!114 &866748469
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -22925,7 +22925,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1425522875}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0.5, y: 0.08, z: -5.5}
   m_LocalScale: {x: 0.9, y: 0.9, z: 0.9}
   m_Children:
@@ -31632,7 +31632,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2018414482}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: -0.5, y: 0.08, z: 3.5}
   m_LocalScale: {x: 0.9, y: 0.9, z: 0.9}
   m_Children:
@@ -31641,7 +31641,7 @@ Transform:
   - {fileID: 1001405539}
   m_Father: {fileID: 202990525}
   m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!114 &2018414484
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CreatureStats.cs
+++ b/Assets/Scripts/CreatureStats.cs
@@ -109,12 +109,12 @@ public class CreatureStats : MonoBehaviour
 
     private int HitChance()
     {
-        return 75 + GetEffectiveAgility() / 4;
+        return 75 + (GetEffectiveAgility() / 4);
     }
 
     private int DodgeChance()
     {
-        return 0 + GetEffectiveAgility() / 2;
+        return 0 + (GetEffectiveAgility() / 2);
     }
 
     private bool PercentRoll(int percent)

--- a/Assets/Scripts/CreatureStats.cs
+++ b/Assets/Scripts/CreatureStats.cs
@@ -141,31 +141,28 @@ public class CreatureStats : MonoBehaviour
     }
 
     // Returns true if floats are within 15.0f of each other.
-    // compare Mathf.Approximately.
-    private bool VeryApproximately(float f1, float f2)
+    // compare Mathf.Approximately, this has a much larger tolerance window.
+    private bool VeryApproximateMatch(float f1, float f2)
     {
         if (Mathf.Abs(f1 - f2) < 15.0f) return true;
         return false;
     }
 
-    // Returns true if the target is being attacked from the side or rear.
-    // Side/read attacks double the chance of a critical hit.
+    // Returns true if the target is being attacked from the rear, left, or right.
+    // Side/rear attacks double the chance of a critical hit.
     public bool IsFlanking(CreatureStats target)
     {
         float rotation1 = target.transform.eulerAngles.y;
         float rotation2 = transform.eulerAngles.y;
-        bool flanking = !VeryApproximately(Mathf.Abs(rotation1 - rotation2), 180.0f);
-        return flanking;
+        return !VeryApproximateMatch(Mathf.Abs(rotation1 - rotation2), 180.0f);
     }
 
     // Returns true if the target is being attacked from the rear.
-    // Rear attacks do a bonus 0-10 damage plus one half of agility.
     public bool IsBehind(CreatureStats target)
     {
         float rotation1 = target.transform.eulerAngles.y;
         float rotation2 = transform.eulerAngles.y;
-        bool behind = VeryApproximately(Mathf.Abs(rotation1 - rotation2), 0.0f) || VeryApproximately(Mathf.Abs(rotation1 - rotation2), 360.0f);
-        return behind;
+        return VeryApproximateMatch(Mathf.Abs(rotation1 - rotation2), 0.0f) || VeryApproximately(Mathf.Abs(rotation1 - rotation2), 360.0f);
     }
 
     public bool IsCrit(CreatureStats target)
@@ -195,6 +192,7 @@ public class CreatureStats : MonoBehaviour
             DisplayPopup("Rear attack!");
             dam += BonusRearDamage();
         }
+        // Critical hits apply a +50% multiplier, after all other modifiers are considered.
         if (IsCrit(target))
         {
             target.DisplayPopup("CRITICAL HIT! " + dam + " damage inflicted!");

--- a/Assets/Scripts/CreatureStats.cs
+++ b/Assets/Scripts/CreatureStats.cs
@@ -52,37 +52,37 @@ public class CreatureStats : MonoBehaviour
     // Average of strength and strength times lifepercent
     protected int GetEffectiveStrength()
     {
-        float[] ar = new float[2] { Strength, Strength * percentHealth() };
+        float[] ar = new float[2] { Strength, Strength * PercentHealth() };
         return Mathf.RoundToInt(ar.Average());
     }
 
     // Average of agility and agility times lifepercent
     protected int GetEffectiveAgility()
     {
-        float[] ar = new float[2] { Agility, Agility * percentHealth() };
+        float[] ar = new float[2] { Agility, Agility * PercentHealth() };
         return Mathf.RoundToInt(ar.Average());
     }
 
     // Average of intelligence and intelligence times lifepercent
     protected int GetEffectiveIntelligence()
     {
-        float[] ar = new float[2] { Intelligence, Intelligence * percentHealth() };
+        float[] ar = new float[2] { Intelligence, Intelligence * PercentHealth() };
         return Mathf.RoundToInt(ar.Average());
     }
 
     // Average of Speed and Speed times lifepercent
     protected int GetEffectiveSpeed()
     {
-        float[] ar = new float[2] { Speed, Speed * percentHealth() };
+        float[] ar = new float[2] { Speed, Speed * PercentHealth() };
         return Mathf.RoundToInt(ar.Average());
     }
 
-    private float percentHealth()
+    private float PercentHealth()
     {
         return (float)CurrentHealth / (float)MaxHealth;
     }
 
-    private float percentStamina()
+    private float PercentStamina()
     {
         return (float)CurrentStamina / (float)MaxStamina;
     }
@@ -103,28 +103,35 @@ public class CreatureStats : MonoBehaviour
             CurrentHealth -= (amount - CurrentStamina);
             CurrentStamina = 0;
         }
-        healthBarScript.SetPercent(percentHealth());
-        staminaBarScript.SetPercent(percentStamina());
+        healthBarScript.SetPercent(PercentHealth());
+        staminaBarScript.SetPercent(PercentStamina());
     }
 
-    private int hitChance()
+    private int HitChance()
     {
         return 75 + GetEffectiveAgility() / 4;
     }
 
-    private int dodgeChance()
+    private int DodgeChance()
     {
         return 0 + GetEffectiveAgility() / 2;
     }
 
-    private bool percentRoll(int percent)
+    private bool PercentRoll(int percent)
     {
         return rng.Next(0, 99) < percent;
     }
 
-    private int damageInflicted()
+    // Damage from a basic attack is 1-11 plus half of strength.
+    private int DamageInflicted()
     {
-        return rng.Next(0, 10) + GetEffectiveStrength() / 2;
+        return rng.Next(1, 11) + GetEffectiveStrength() / 2;
+    }
+
+    // Bonus damage from a rear attack is 1-5 plus a quarter of agility.
+    private int BonusRearDamage()
+    {
+        return rng.Next(1, 5) + GetEffectiveAgility() / 4;
     }
 
     private void DisplayPopup(string text)
@@ -133,19 +140,70 @@ public class CreatureStats : MonoBehaviour
         textLabelText = text;
     }
 
+    // Returns true if floats are within 15.0f of each other.
+    // compare Mathf.Approximately.
+    private bool VeryApproximately(float f1, float f2)
+    {
+        if (Mathf.Abs(f1 - f2) < 15.0f) return true;
+        return false;
+    }
+
+    // Returns true if the target is being attacked from the side or rear.
+    // Side/read attacks double the chance of a critical hit.
+    public bool IsFlanking(CreatureStats target)
+    {
+        float rotation1 = target.transform.eulerAngles.y;
+        float rotation2 = transform.eulerAngles.y;
+        bool flanking = !VeryApproximately(Mathf.Abs(rotation1 - rotation2), 180.0f);
+        return flanking;
+    }
+
+    // Returns true if the target is being attacked from the rear.
+    // Rear attacks do a bonus 0-10 damage plus one half of agility.
+    public bool IsBehind(CreatureStats target)
+    {
+        float rotation1 = target.transform.eulerAngles.y;
+        float rotation2 = transform.eulerAngles.y;
+        bool behind = VeryApproximately(Mathf.Abs(rotation1 - rotation2), 0.0f) || VeryApproximately(Mathf.Abs(rotation1 - rotation2), 360.0f);
+        return behind;
+    }
+
+    public bool IsCrit(CreatureStats target)
+    {
+        int chance = GetEffectiveIntelligence() / 10;
+        if (IsFlanking(target))
+        {
+            chance *= 2;
+        }
+        return PercentRoll(chance);
+    }
+
     public void PerformAttack(CreatureStats target)
     {
-        if (!percentRoll(hitChance())) {
+        if (!PercentRoll(HitChance())) {
             DisplayPopup("Miss!");
             return;
         }
-        if (percentRoll(target.dodgeChance()))
+        if (PercentRoll(target.DodgeChance()))
         {
             target.DisplayPopup("Dodge!");
             return;
         }
-        int dam = damageInflicted();
-        target.DisplayPopup(dam + " damage inflicted!");
+        int dam = DamageInflicted();
+        if (IsBehind(target))
+        {
+            DisplayPopup("Rear attack!");
+            dam += BonusRearDamage();
+        }
+        if (IsCrit(target))
+        {
+            target.DisplayPopup("CRITICAL HIT! " + dam + " damage inflicted!");
+            dam += (dam / 2);
+        }
+        else
+        {
+            target.DisplayPopup(dam + " damage inflicted!");
+        }
         target.ReceiveDamage(dam);
     }
 }


### PR DESCRIPTION
Adds bonus damage for rear attacks and critical hits.

Currently, basic attacks inflict an average of 6 damage, plus one half of effective strength (with a random plus or minus 5).

Now, if you attack from behind, you do additional bonus damage which is an average of three plus one quarter your agility (with a random plus or minus 2).

Furthermore, there are rare critical hits that inflict an additional +50% damage on top of whatever other damage you do. The chance of these is 1% per ten points of effective intelligence, but the chance is doubled if you are attacking from behind or from the side.