### PR TITLE
Aveybranch

### DIFF
--- a/Assets/Plugins/GameCreator/Characters/Animations/Controllers/Locomotion.controller
+++ b/Assets/Plugins/GameCreator/Characters/Animations/Controllers/Locomotion.controller
@@ -333,6 +333,12 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 0}
+  - m_Name: IsCastingSpell
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -1110,6 +1116,7 @@ AnimatorState:
   - {fileID: 1276603253263020473}
   - {fileID: 6152938425947859404}
   - {fileID: -1923758395041286317}
+  - {fileID: 1168564791401249932}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -1241,16 +1248,19 @@ AnimatorStateMachine:
     m_Position: {x: 230, y: 280, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -8751060723842522459}
-    m_Position: {x: 250, y: -40, z: 0}
+    m_Position: {x: 210, y: -40, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 480863066787906610}
-    m_Position: {x: 520, y: 30, z: 0}
+    m_Position: {x: 550, y: 50, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 5757829740258080874}
     m_Position: {x: 550, y: 160, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -7421761563833389546}
     m_Position: {x: 540, y: 260, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 7113105887157405355}
+    m_Position: {x: 430, y: -40, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
@@ -1278,6 +1288,31 @@ AnimatorTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 1
+--- !u!1101 &1168564791401249932
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: IsCastingSpell
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 7113105887157405355}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.5081967
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &1276603253263020473
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -1378,6 +1413,31 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &4739929951122503085
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: IsCastingSpell
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102676722091324818}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.78571427
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &5757829740258080874
 AnimatorState:
   serializedVersion: 5
@@ -1431,3 +1491,30 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1102 &7113105887157405355
+AnimatorState:
+  serializedVersion: 5
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Character@clap
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 4739929951122503085}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 74441402851494984, guid: ddbb0c2ffa47e48f295597feb916b6f9, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 

--- a/Assets/Resources.meta
+++ b/Assets/Resources.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 3a590cccb7f053c479697063954103c5
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Resources.meta
+++ b/Assets/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3a590cccb7f053c479697063954103c5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Combat.unity
+++ b/Assets/Scenes/Combat.unity
@@ -44405,6 +44405,7 @@ GameObject:
   - component: {fileID: 1648450030}
   - component: {fileID: 1648450029}
   - component: {fileID: 1648450028}
+  - component: {fileID: 1648450032}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -44494,6 +44495,20 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!114 &1648450032
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1648450027}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fc3ab3220a4e03140a839da1855c47bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  popupTextPrefab: {fileID: 4850717382184306677, guid: f0f7a688a66b6f741a4a65b582a2f927,
+    type: 3}
 --- !u!1 &1650123241
 GameObject:
   m_ObjectHideFlags: 0
@@ -57301,10 +57316,10 @@ RectTransform:
   m_Father: {fileID: 166531482}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0.9, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 150}
-  m_SizeDelta: {x: 160, y: 30}
+  m_SizeDelta: {x: 0, y: 30}
   m_Pivot: {x: -3, y: 1}
 --- !u!114 &2112417339
 MonoBehaviour:

--- a/Assets/Scenes/Combat.unity
+++ b/Assets/Scenes/Combat.unity
@@ -2389,6 +2389,7 @@ GameObject:
   - component: {fileID: 98393262}
   - component: {fileID: 98393261}
   - component: {fileID: 98393260}
+  - component: {fileID: 98393271}
   m_Layer: 0
   m_Name: Player Character 3
   m_TagString: Untagged
@@ -2779,6 +2780,18 @@ MonoBehaviour:
     verticalSpeed: 0
     normal: {x: 0, y: 0, z: 0}
   save: 0
+--- !u!114 &98393271
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 98393258}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1899a183c0749648b7b8e26bb1234c0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &99567266
 GameObject:
   m_ObjectHideFlags: 0
@@ -6476,6 +6489,7 @@ GameObject:
   - component: {fileID: 231315689}
   - component: {fileID: 231315688}
   - component: {fileID: 231315687}
+  - component: {fileID: 231315698}
   m_Layer: 0
   m_Name: Player Character 4
   m_TagString: Untagged
@@ -6866,6 +6880,18 @@ MonoBehaviour:
     verticalSpeed: 0
     normal: {x: 0, y: 0, z: 0}
   save: 0
+--- !u!114 &231315698
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 231315685}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1899a183c0749648b7b8e26bb1234c0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &233271831
 GameObject:
   m_ObjectHideFlags: 0
@@ -18841,6 +18867,7 @@ GameObject:
   - component: {fileID: 662700919}
   - component: {fileID: 662700920}
   - component: {fileID: 662700921}
+  - component: {fileID: 662700922}
   m_Layer: 0
   m_Name: Player Character 2
   m_TagString: Untagged
@@ -19231,6 +19258,18 @@ MonoBehaviour:
   agility: 70
   intelligence: 90
   name: Rogue
+--- !u!114 &662700922
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 662700909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1899a183c0749648b7b8e26bb1234c0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &662887152
 GameObject:
   m_ObjectHideFlags: 0
@@ -38951,6 +38990,7 @@ GameObject:
   - component: {fileID: 1425522885}
   - component: {fileID: 1425522886}
   - component: {fileID: 1425522887}
+  - component: {fileID: 1425522888}
   m_Layer: 0
   m_Name: Player Character 1
   m_TagString: Untagged
@@ -39341,6 +39381,18 @@ MonoBehaviour:
   agility: 10
   intelligence: 30
   name: Speedster
+--- !u!114 &1425522888
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1425522875}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1899a183c0749648b7b8e26bb1234c0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1427171464
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Combat/Action.cs
+++ b/Assets/Scripts/Combat/Action.cs
@@ -13,6 +13,16 @@ public class Action : MonoBehaviour
 
     private CombatController combatController;
 
+    protected enum phase
+    {
+        NONE,
+        MOVING,
+        CASTING,
+        ATTACKING,
+    };
+
+    protected phase currentPhase = phase.NONE;
+
     // Start is called before the first frame update
     virtual protected void Start()
     {

--- a/Assets/Scripts/Combat/ActionBasicAttack.cs
+++ b/Assets/Scripts/Combat/ActionBasicAttack.cs
@@ -20,17 +20,17 @@ public class ActionBasicAttack : ActionMove
         {
             return;
         }
-        if (phase == PHASE_MOVING)
+        if (currentPhase == phase.MOVING)
         {
             Move();
         }
-        else if (phase == PHASE_ATTACKING)
+        else if (currentPhase == phase.ATTACKING)
         {
             AttackPhase();
         }
         else
         {
-            phase = PHASE_NONE;
+            currentPhase = phase.NONE;
         }
     }
 
@@ -66,7 +66,7 @@ public class ActionBasicAttack : ActionMove
         }
         else
         {
-            phase = PHASE_NONE;
+            currentPhase = phase.NONE;
             StartCoroutine(WaitForAttackAnimations(1.0f));
         }
     }

--- a/Assets/Scripts/Combat/ActionMove.cs
+++ b/Assets/Scripts/Combat/ActionMove.cs
@@ -30,7 +30,7 @@ public class ActionMove : Action
         }
         else
         {
-            currentPhase = 0;
+            currentPhase = phase.NONE;
             EndAction();
         }
     }

--- a/Assets/Scripts/Combat/ActionMove.cs
+++ b/Assets/Scripts/Combat/ActionMove.cs
@@ -4,15 +4,10 @@ using UnityEngine;
 
 public class ActionMove : Action
 {
-    protected const int PHASE_NONE = 0;
-    protected const int PHASE_MOVING = 1;
-    protected const int PHASE_ATTACKING = 2;
 
     [SerializeField] private float moveSpeed = 2;
 
     protected Stack<Tile> path = new Stack<Tile>();
-
-    protected int phase = PHASE_NONE;
 
     // Extra tiles at the end of the action
     protected int reserve_tiles = 0;
@@ -29,13 +24,13 @@ public class ActionMove : Action
         {
             return;
         }
-        if (phase == PHASE_MOVING)
+        if (currentPhase == phase.MOVING)
         {
             Move();
         }
         else
         {
-            phase = 0;
+            currentPhase = 0;
             EndAction();
         }
     }
@@ -73,13 +68,13 @@ public class ActionMove : Action
         else
         {
             anim.SetBool("IsWalking", false);
-            phase = PHASE_ATTACKING;
+            currentPhase = phase.ATTACKING;
         }
     }
 
     override public void BeginAction(Tile targetTile)
     {
-        phase = PHASE_MOVING;
+        currentPhase = phase.MOVING;
         CalculatePath(targetTile);
         base.BeginAction(targetTile);
     }

--- a/Assets/Scripts/Combat/ActionRegenerate.cs
+++ b/Assets/Scripts/Combat/ActionRegenerate.cs
@@ -4,11 +4,12 @@ using UnityEngine;
 
 public class ActionRegenerate : Action
 {
-
     protected const int PHASE_NONE = 0;
     protected const int PHASE_ANIMATING = 1;
 
     protected int phase = PHASE_NONE;
+
+    public int FIXED_COST = 2;
 
     private IEnumerator WaitForRegenerationAnimations(float fDuration)
     {
@@ -32,7 +33,8 @@ public class ActionRegenerate : Action
         }
         if (phase == PHASE_NONE)
         {
-            spentActionPoints += 2;
+            GetComponent<CreatureStats>().Animate("IsCastingSpell");
+            spentActionPoints += FIXED_COST;
             phase = PHASE_ANIMATING;
             new StatusEffect(
                 (int)StatusEffect.EffectType.EFFECT_REGENERATION,

--- a/Assets/Scripts/Combat/ActionRegenerate.cs
+++ b/Assets/Scripts/Combat/ActionRegenerate.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ActionRegenerate : Action
+{
+
+    protected const int PHASE_NONE = 0;
+    protected const int PHASE_ANIMATING = 1;
+
+    protected int phase = PHASE_NONE;
+
+    private IEnumerator WaitForRegenerationAnimations(float fDuration)
+    {
+        float elapsed = 0f;
+        while (elapsed < fDuration)
+        {
+            elapsed += Time.deltaTime;
+            yield return null;
+        }
+        phase = PHASE_NONE;
+        EndAction();
+        yield break;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (!inProgress)
+        {
+            return;
+        }
+        if (phase == PHASE_NONE)
+        {
+            spentActionPoints += 2;
+            phase = PHASE_ANIMATING;
+            new StatusEffect(
+                (int)StatusEffect.EffectType.EFFECT_REGENERATION,
+                2,
+                GetComponent<CreatureStats>()
+            );
+            StartCoroutine(WaitForRegenerationAnimations(1.0f));
+        }
+    }
+
+}

--- a/Assets/Scripts/Combat/ActionRegenerate.cs
+++ b/Assets/Scripts/Combat/ActionRegenerate.cs
@@ -4,10 +4,6 @@ using UnityEngine;
 
 public class ActionRegenerate : Action
 {
-    protected const int PHASE_NONE = 0;
-    protected const int PHASE_ANIMATING = 1;
-
-    protected int phase = PHASE_NONE;
 
     public int FIXED_COST = 2;
 
@@ -19,7 +15,7 @@ public class ActionRegenerate : Action
             elapsed += Time.deltaTime;
             yield return null;
         }
-        phase = PHASE_NONE;
+        currentPhase = phase.NONE;
         EndAction();
         yield break;
     }
@@ -31,13 +27,13 @@ public class ActionRegenerate : Action
         {
             return;
         }
-        if (phase == PHASE_NONE)
+        if (currentPhase == phase.NONE)
         {
             GetComponent<CreatureStats>().Animate("IsCastingSpell");
             spentActionPoints += FIXED_COST;
-            phase = PHASE_ANIMATING;
+            currentPhase = phase.CASTING;
             new StatusEffect(
-                (int)StatusEffect.EffectType.EFFECT_REGENERATION,
+                (int)StatusEffect.EffectType.REGENERATION,
                 2,
                 GetComponent<CreatureStats>()
             );

--- a/Assets/Scripts/Combat/ActionRegenerate.cs.meta
+++ b/Assets/Scripts/Combat/ActionRegenerate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f1899a183c0749648b7b8e26bb1234c0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Combat/CanvasPrefabs.cs
+++ b/Assets/Scripts/Combat/CanvasPrefabs.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CanvasPrefabs : MonoBehaviour
+{
+    [SerializeField] public PopupText popupTextPrefab;
+}

--- a/Assets/Scripts/Combat/CanvasPrefabs.cs.meta
+++ b/Assets/Scripts/Combat/CanvasPrefabs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fc3ab3220a4e03140a839da1855c47bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -9,7 +9,7 @@ public class CombatController : TileBlockerController
     protected GUIPanel panel;
 
     protected bool isActing = false;
-    [SerializeField] private int actionPoints = 0;
+    [SerializeField] protected int actionPoints = 0;
 
     const int ATTACK_COST = 4;
 

--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -30,7 +30,7 @@ public class CombatController : TileBlockerController
 
     public void BeginTurn()
     {
-        actionPoints = GetComponent<CreatureStats>().GetMaxActionPoints();
+        actionPoints = GetComponent<CreatureStats>().BeginTurnAndGetMaxActionPoints();
         if (DoesGUI()) panel.SetActionPoints(actionPoints);
         isTurn = true;
         AssignCurrentTile();

--- a/Assets/Scripts/Combat/CreatureStats.cs
+++ b/Assets/Scripts/Combat/CreatureStats.cs
@@ -32,16 +32,11 @@ public class CreatureStats : ObjectStats
         rng = new System.Random();
         healthBarScript = healthBar.GetComponent<IndicatorBar>();
         staminaBarScript = staminaBar.GetComponent<IndicatorBar>();
-        maxHealth = endurance + (strength / 5) + 10;
+        maxHealth = endurance + (strength / 5) + 5;
         maxStamina = endurance + 10;
         currentStamina = maxStamina;
         currentHealth = maxHealth;
         base.Start();
-    }
-
-    public void RemoveStatusEffect(StatusEffect effect)
-    {
-        statusEffects.RemoveAll(e => e == effect);
     }
 
     public void RegisterStatusEffect(StatusEffect effect)
@@ -55,6 +50,7 @@ public class CreatureStats : ObjectStats
         {
             effect.PerRoundEffect();
         }
+        statusEffects.RemoveAll(e => e.expired);
         return 5 + GetEffectiveSpeed() / 10;
     }
 

--- a/Assets/Scripts/Combat/CreatureStats.cs
+++ b/Assets/Scripts/Combat/CreatureStats.cs
@@ -2,6 +2,7 @@
 
 using UnityEngine;
 using System.Linq;
+using System.Collections.Generic;
 
 public class CreatureStats : ObjectStats
 {
@@ -21,6 +22,10 @@ public class CreatureStats : ObjectStats
     protected int maxStamina = 1;
     protected int currentStamina = 1;
 
+    protected int currentConcentration = 0;
+
+    private List<StatusEffect> statusEffects = new List<StatusEffect>();
+
     // Start is called before the first frame update
     override protected void Start()
     {
@@ -32,6 +37,25 @@ public class CreatureStats : ObjectStats
         currentStamina = maxStamina;
         currentHealth = maxHealth;
         base.Start();
+    }
+
+    public void RemoveStatusEffect(StatusEffect effect)
+    {
+        statusEffects.RemoveAll(e => e == effect);
+    }
+
+    public void RegisterStatusEffect(StatusEffect effect)
+    {
+        statusEffects.Add(effect);
+    }
+
+    public int BeginTurnAndGetMaxActionPoints()
+    {
+        foreach (StatusEffect effect in statusEffects)
+        {
+            effect.PerRoundEffect();
+        }
+        return 5 + GetEffectiveSpeed() / 10;
     }
 
     public string StaminaString()
@@ -72,9 +96,18 @@ public class CreatureStats : ObjectStats
         return (float)currentStamina / (float)maxStamina;
     }
 
-    public int GetMaxActionPoints()
+    // Healing heals health but not stamina.
+    public void ReceiveHealing(int amount)
     {
-        return 5 + GetEffectiveSpeed() / 10;
+        if (currentHealth + amount > maxHealth)
+        {
+            currentHealth = maxHealth;
+        }
+        else
+        {
+            currentHealth += amount;
+        }
+        healthBarScript.SetPercent(PercentHealth());
     }
 
     override public void ReceiveDamage(int amount)

--- a/Assets/Scripts/Combat/CreatureStats.cs
+++ b/Assets/Scripts/Combat/CreatureStats.cs
@@ -95,6 +95,7 @@ public class CreatureStats : ObjectStats
     // Healing heals health but not stamina.
     public void ReceiveHealing(int amount)
     {
+        DisplayPopup(amount + " healing");
         if (currentHealth + amount > maxHealth)
         {
             currentHealth = maxHealth;
@@ -108,6 +109,7 @@ public class CreatureStats : ObjectStats
 
     override public void ReceiveDamage(int amount)
     {
+        DisplayPopup(amount + " damage");
         if (currentStamina >= amount)
         {
             currentStamina -= amount;
@@ -222,7 +224,6 @@ public class CreatureStats : ObjectStats
         Animate("IsAttacking");
         if (!PercentRoll(HitChance())) {
             target.Animate("IsDodging");
-            DisplayPopup("Miss!");
             DisplayPopup("Miss");
             return;
         }
@@ -249,7 +250,6 @@ public class CreatureStats : ObjectStats
         {
             DisplayPopup("Backstab");
         }
-        target.DisplayPopup(dam + " damage");
         target.ReceiveDamage(dam);
     }
 }

--- a/Assets/Scripts/Combat/CreatureStats.cs
+++ b/Assets/Scripts/Combat/CreatureStats.cs
@@ -27,7 +27,7 @@ public class CreatureStats : ObjectStats
         rng = new System.Random();
         healthBarScript = healthBar.GetComponent<IndicatorBar>();
         staminaBarScript = staminaBar.GetComponent<IndicatorBar>();
-        maxHealth = endurance + (strength / 5) + 5;
+        maxHealth = endurance + (strength / 5) + 10;
         maxStamina = endurance + 10;
         currentStamina = maxStamina;
         currentHealth = maxHealth;

--- a/Assets/Scripts/Combat/ObjectStats.cs
+++ b/Assets/Scripts/Combat/ObjectStats.cs
@@ -84,6 +84,7 @@ public class ObjectStats : MonoBehaviour
         anim.SetBool("IsAttacking", false);
         anim.SetBool("IsDodging", false);
         anim.SetBool("IsGettingDamaged", false);
+        anim.SetBool("IsCastingSpell", false);
     }
 
     virtual public void Animate(string animName)

--- a/Assets/Scripts/Combat/ObjectStats.cs
+++ b/Assets/Scripts/Combat/ObjectStats.cs
@@ -36,6 +36,7 @@ public class ObjectStats : MonoBehaviour
 
     public virtual void ReceiveDamage(int amount)
     {
+        DisplayPopup(amount + " damage");
         currentHealth -= (amount);
         if (currentHealth <= 0)
         {

--- a/Assets/Scripts/Combat/PlayerController.cs
+++ b/Assets/Scripts/Combat/PlayerController.cs
@@ -116,11 +116,13 @@ public class PlayerController : CombatController
             {
                 Action atk = GetComponent<ActionBasicAttack>();
                 atk.BeginAction(clickedTile);
+                return;
             }
             else
             {
                 Action move = GetComponent<ActionMove>();
                 move.BeginAction(clickedTile);
+                return;
             }
         }
         else
@@ -130,6 +132,13 @@ public class PlayerController : CombatController
                 ClearMouseHover();
                 SetMouseHover();
             }
+        }
+        if (Input.GetKeyDown("r"))
+        {
+            ActionRegenerate regen = GetComponent<ActionRegenerate>();
+            if (regen == null || actionPoints < regen.FIXED_COST) return;
+            regen.BeginAction(null);
+            return;
         }
     }
 }

--- a/Assets/Scripts/Combat/PopupTextController.cs
+++ b/Assets/Scripts/Combat/PopupTextController.cs
@@ -3,7 +3,8 @@ using UnityEngine;
 
 public class PopupTextController : MonoBehaviour
 {
-    private static string popupTextPrefabFilePath = "Assets/Prefabs/PopupTextParent.prefab";
+    // private static string popupTextPrefabFilePath = "Assets/Prefabs/PopupTextParent";
+    private static string popupTextPrefabFilePath = "Prefabs/PopupTextParent.prefab";
     private static PopupText popupTextPrefab;
     private static string canvasName = "Canvas";
     private static GameObject canvas;
@@ -11,7 +12,8 @@ public class PopupTextController : MonoBehaviour
     public static void Initialize()
     {
         canvas = GameObject.Find(canvasName);
-        popupTextPrefab = AssetDatabase.LoadAssetAtPath<PopupText>(popupTextPrefabFilePath);
+        popupTextPrefab = canvas.GetComponent<CanvasPrefabs>().popupTextPrefab;
+        // popupTextPrefab = AssetDatabase.LoadAssetAtPath<PopupText>(popupTextPrefabFilePath);
     }
 
     public static void CreatePopupText(string text, Transform transform)

--- a/Assets/Scripts/Combat/PopupTextController.cs
+++ b/Assets/Scripts/Combat/PopupTextController.cs
@@ -3,8 +3,6 @@ using UnityEngine;
 
 public class PopupTextController : MonoBehaviour
 {
-    // private static string popupTextPrefabFilePath = "Assets/Prefabs/PopupTextParent";
-    private static string popupTextPrefabFilePath = "Prefabs/PopupTextParent.prefab";
     private static PopupText popupTextPrefab;
     private static string canvasName = "Canvas";
     private static GameObject canvas;
@@ -13,7 +11,6 @@ public class PopupTextController : MonoBehaviour
     {
         canvas = GameObject.Find(canvasName);
         popupTextPrefab = canvas.GetComponent<CanvasPrefabs>().popupTextPrefab;
-        // popupTextPrefab = AssetDatabase.LoadAssetAtPath<PopupText>(popupTextPrefabFilePath);
     }
 
     public static void CreatePopupText(string text, Transform transform)

--- a/Assets/Scripts/Combat/StatusEffect.cs
+++ b/Assets/Scripts/Combat/StatusEffect.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class StatusEffect
+{
+    public enum EffectType
+    {
+        EFFECT_REGENERATION,
+    };
+
+    EffectType type;
+    int roundsRemaining = 0;
+    CreatureStats target;
+    int powerLevel;
+
+    // Some status effects have varying power levels, others default to -1
+    public StatusEffect(EffectType effectType, int durationRounds, CreatureStats effectTarget, int effectPowerLevel = -1)
+    {
+        roundsRemaining = durationRounds;
+        type = effectType;
+        target = effectTarget;
+        powerLevel = effectPowerLevel;
+        target.RegisterStatusEffect(this);
+    }
+
+    // The CreatureStats is responsible for calling this every round before its action.
+    public void PerRoundEffect()
+    {
+        switch (type)
+        {
+            case EffectType.EFFECT_REGENERATION:
+                target.ReceiveHealing(5);
+                break;
+        }
+        roundsRemaining--;
+        if (roundsRemaining == 0)
+        {
+            target.RemoveStatusEffect(this);
+        }
+    }
+}

--- a/Assets/Scripts/Combat/StatusEffect.cs
+++ b/Assets/Scripts/Combat/StatusEffect.cs
@@ -13,6 +13,7 @@ public class StatusEffect
     int roundsRemaining = 0;
     CreatureStats target;
     int powerLevel;
+    public bool expired = false;
 
     // Some status effects have varying power levels, others default to -1
     public StatusEffect(EffectType effectType, int durationRounds, CreatureStats effectTarget, int effectPowerLevel = -1)
@@ -36,7 +37,7 @@ public class StatusEffect
         roundsRemaining--;
         if (roundsRemaining == 0)
         {
-            target.RemoveStatusEffect(this);
+            expired = true;
         }
     }
 }

--- a/Assets/Scripts/Combat/StatusEffect.cs
+++ b/Assets/Scripts/Combat/StatusEffect.cs
@@ -6,7 +6,7 @@ public class StatusEffect
 {
     public enum EffectType
     {
-        EFFECT_REGENERATION,
+        REGENERATION,
     };
 
     EffectType type;
@@ -30,7 +30,7 @@ public class StatusEffect
     {
         switch (type)
         {
-            case EffectType.EFFECT_REGENERATION:
+            case EffectType.REGENERATION:
                 target.ReceiveHealing(5);
                 break;
         }

--- a/Assets/Scripts/Combat/StatusEffect.cs.meta
+++ b/Assets/Scripts/Combat/StatusEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cfb14689801b0b4418cbb7c7e0f3b85f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Combat/Tile.cs
+++ b/Assets/Scripts/Combat/Tile.cs
@@ -48,7 +48,12 @@ public class Tile : MonoBehaviour
         }
         else if (isBlocked)
         {
-            GetComponent<Renderer>().material.color = Color.red;
+            if (isSelectable)
+            {
+                GetComponent<Renderer>().material.color = Color.red;
+            } else {
+                GetComponent<Renderer>().material.color = new Color(0.5f, 0, 0, 1);
+            }
         }
         else if (isSelectable)
         {


### PR DESCRIPTION
Sets up a basic framework for status effects and a regeneration action as an example of how they would be evoked.

The basic gist of it is that there is a StatusEffect object that can be instantiated, and its constructor takes as arguments a type, duration, target, and (optionally, for effects with varying power) a powerlevel.

Every CreatureStats can have zero or more StatusEffects, and at the beginning of its turn it will trigger all of their PerRoundEffects, typically exerting some positive or negative influence on the CreatureStats itself.

Once the StatusEffect runs out of rounds and expires, it is removed from the target and garbage collected.